### PR TITLE
Make tab use consistent and sgx_printf return void

### DIFF
--- a/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.cpp
+++ b/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.cpp
@@ -76,13 +76,13 @@ int sgx_setsockopt(int s, int level, int optname, const void *optval, int optlen
 
 int sgx_socket(int af, int type, int protocol)
 {
-		int retv;
-		sgx_status_t sgx_retv;
-		if((sgx_retv = ocall_sgx_socket(&retv, af, type, protocol)) != SGX_SUCCESS){
-			printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
-			sgx_exit(EXIT_FAILURE);
-		}
-		return retv;
+	int retv;
+	sgx_status_t sgx_retv;
+	if((sgx_retv = ocall_sgx_socket(&retv, af, type, protocol)) != SGX_SUCCESS){
+		printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
+		sgx_exit(EXIT_FAILURE);
+	}
+	return retv;
 }
 
 int sgx_bind(int s, const struct sockaddr *addr, int addrlen)
@@ -176,38 +176,38 @@ char *sgx_getenv(const char *env)
 	return NULL;
 }
 
-int sgx_printf(const char *fmt, ...)
+void sgx_printf(const char *fmt, ...)
 {
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    ocall_print_string(buf);
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	ocall_print_string(buf);
 }
 
 void sgx_printe(const char *fname, const char *fmt, ...)
 {
-    char ebuf[BUFSIZ] = {'\0'};
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    snprintf(ebuf, sizeof(ebuf), "Error: %s failed!: %s\n", fname, buf);
-    ocall_print_string(ebuf);
+	char ebuf[BUFSIZ] = {'\0'};
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	snprintf(ebuf, sizeof(ebuf), "Error: %s failed!: %s\n", fname, buf);
+	ocall_print_string(ebuf);
 }
 
 void sgx_printl(const char *fname, const char *fmt, ...)
 {
-    char ebuf[BUFSIZ] = {'\0'};
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    snprintf(ebuf, sizeof(ebuf), "LOG: %s: %s\n", fname, buf);
-    ocall_print_string(ebuf);
+	char ebuf[BUFSIZ] = {'\0'};
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	snprintf(ebuf, sizeof(ebuf), "LOG: %s: %s\n", fname, buf);
+	ocall_print_string(ebuf);
 }
 
 long sgx_rand(void)
@@ -358,5 +358,5 @@ static const int32_t *const ptable2 = table2+128;
 
 const int32_t **__ctype_tolower_loc(void)
 {
-    return (const int32_t **)&ptable2;
+	return (const int32_t **)&ptable2;
 }

--- a/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.h
+++ b/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.h
@@ -32,7 +32,7 @@ int sgx_read(int fd, void *buf, int n);
 int sgx_write(int fd, const void *buf, int n);
 int sgx_close(int fd);
 char *sgx_getenv(const char *env);
-int sgx_printf(const char *fmt, ...);
+void sgx_printf(const char *fmt, ...);
 void sgx_printe(const char *fname, const char *fmt, ...);
 void sgx_printl(const char *fname, const char *fmt, ...);
 long sgx_rand(void);

--- a/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.cpp
+++ b/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.cpp
@@ -76,13 +76,13 @@ int sgx_setsockopt(int s, int level, int optname, const void *optval, int optlen
 
 int sgx_socket(int af, int type, int protocol)
 {
-		int retv;
-		sgx_status_t sgx_retv;
-		if((sgx_retv = ocall_sgx_socket(&retv, af, type, protocol)) != SGX_SUCCESS){
-			printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
-			sgx_exit(EXIT_FAILURE);
-		}
-		return retv;
+	int retv;
+	sgx_status_t sgx_retv;
+	if((sgx_retv = ocall_sgx_socket(&retv, af, type, protocol)) != SGX_SUCCESS){
+		printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
+		sgx_exit(EXIT_FAILURE);
+	}
+	return retv;
 }
 
 int sgx_bind(int s, const struct sockaddr *addr, int addrlen)
@@ -176,38 +176,38 @@ char *sgx_getenv(const char *env)
 	return NULL;
 }
 
-int sgx_printf(const char *fmt, ...)
+void sgx_printf(const char *fmt, ...)
 {
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    ocall_print_string(buf);
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	ocall_print_string(buf);
 }
 
 void sgx_printe(const char *fname, const char *fmt, ...)
 {
-    char ebuf[BUFSIZ] = {'\0'};
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    snprintf(ebuf, sizeof(ebuf), "Error: %s failed!: %s\n", fname, buf);
-    ocall_print_string(ebuf);
+	char ebuf[BUFSIZ] = {'\0'};
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	snprintf(ebuf, sizeof(ebuf), "Error: %s failed!: %s\n", fname, buf);
+	ocall_print_string(ebuf);
 }
 
 void sgx_printl(const char *fname, const char *fmt, ...)
 {
-    char ebuf[BUFSIZ] = {'\0'};
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    snprintf(ebuf, sizeof(ebuf), "LOG: %s: %s\n", fname, buf);
-    ocall_print_string(ebuf);
+	char ebuf[BUFSIZ] = {'\0'};
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	snprintf(ebuf, sizeof(ebuf), "LOG: %s: %s\n", fname, buf);
+	ocall_print_string(ebuf);
 }
 
 long sgx_rand(void)
@@ -358,5 +358,5 @@ static const int32_t *const ptable2 = table2+128;
 
 const int32_t **__ctype_tolower_loc(void)
 {
-    return (const int32_t **)&ptable2;
+	return (const int32_t **)&ptable2;
 }

--- a/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.h
+++ b/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.h
@@ -32,7 +32,7 @@ int sgx_read(int fd, void *buf, int n);
 int sgx_write(int fd, const void *buf, int n);
 int sgx_close(int fd);
 char *sgx_getenv(const char *env);
-int sgx_printf(const char *fmt, ...);
+void sgx_printf(const char *fmt, ...);
 void sgx_printe(const char *fname, const char *fmt, ...);
 void sgx_printl(const char *fname, const char *fmt, ...);
 long sgx_rand(void);

--- a/Wrappers/App/Ocall_implements.cpp
+++ b/Wrappers/App/Ocall_implements.cpp
@@ -4,7 +4,7 @@
 long ocall_sgx_clock(void)
 {
 	struct timespec tstart={0,0}, tend={0,0};
-    clock_gettime(CLOCK_MONOTONIC, &tstart);
+	clock_gettime(CLOCK_MONOTONIC, &tstart);
 	return tstart.tv_sec * 1000000 + tstart.tv_nsec/1000; // Return micro seconds
 }
 
@@ -30,7 +30,7 @@ int ocall_sgx_gettimeofday(void *tv, int tv_size)
 
 int ocall_sgx_getsockopt(int s, int level, int optname, char *optval, int optval_len, int* optlen)
 {
-    return getsockopt(s, level, optname, optval, (socklen_t *)optlen);
+	return getsockopt(s, level, optname, optval, (socklen_t *)optlen);
 }
 
 int ocall_sgx_setsockopt(int s, int level, int optname, const void *optval, int optlen)
@@ -98,7 +98,7 @@ int ocall_sgx_getenv(const char *env, int envlen, char *ret_str,int ret_len)
 
 void ocall_print_string(const char *str)
 {
-    printf("%s", str);
+	printf("%s", str);
 }
 
 void ocall_sgx_exit(int e)

--- a/Wrappers/Enclave/Ocall_wrappers.cpp
+++ b/Wrappers/Enclave/Ocall_wrappers.cpp
@@ -76,13 +76,13 @@ int sgx_setsockopt(int s, int level, int optname, const void *optval, int optlen
 
 int sgx_socket(int af, int type, int protocol)
 {
-		int retv;
-		sgx_status_t sgx_retv;
-		if((sgx_retv = ocall_sgx_socket(&retv, af, type, protocol)) != SGX_SUCCESS){
-			printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
-			sgx_exit(EXIT_FAILURE);
-		}
-		return retv;
+	int retv;
+	sgx_status_t sgx_retv;
+	if((sgx_retv = ocall_sgx_socket(&retv, af, type, protocol)) != SGX_SUCCESS){
+		printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
+		sgx_exit(EXIT_FAILURE);
+	}
+	return retv;
 }
 
 int sgx_bind(int s, const struct sockaddr *addr, int addrlen)
@@ -176,38 +176,38 @@ char *sgx_getenv(const char *env)
 	return NULL;
 }
 
-int sgx_printf(const char *fmt, ...)
+void sgx_printf(const char *fmt, ...)
 {
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    ocall_print_string(buf);
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	ocall_print_string(buf);
 }
 
 void sgx_printe(const char *fname, const char *fmt, ...)
 {
-    char ebuf[BUFSIZ] = {'\0'};
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    snprintf(ebuf, sizeof(ebuf), "Error: %s failed!: %s\n", fname, buf);
-    ocall_print_string(ebuf);
+	char ebuf[BUFSIZ] = {'\0'};
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	snprintf(ebuf, sizeof(ebuf), "Error: %s failed!: %s\n", fname, buf);
+	ocall_print_string(ebuf);
 }
 
 void sgx_printl(const char *fname, const char *fmt, ...)
 {
-    char ebuf[BUFSIZ] = {'\0'};
-    char buf[BUFSIZ] = {'\0'};
-    va_list ap;
-    va_start(ap, fmt);
-    vsnprintf(buf, BUFSIZ, fmt, ap);
-    va_end(ap);
-    snprintf(ebuf, sizeof(ebuf), "LOG: %s: %s\n", fname, buf);
-    ocall_print_string(ebuf);
+	char ebuf[BUFSIZ] = {'\0'};
+	char buf[BUFSIZ] = {'\0'};
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, BUFSIZ, fmt, ap);
+	va_end(ap);
+	snprintf(ebuf, sizeof(ebuf), "LOG: %s: %s\n", fname, buf);
+	ocall_print_string(ebuf);
 }
 
 long sgx_rand(void)
@@ -358,5 +358,5 @@ static const int32_t *const ptable2 = table2+128;
 
 const int32_t **__ctype_tolower_loc(void)
 {
-    return (const int32_t **)&ptable2;
+	return (const int32_t **)&ptable2;
 }

--- a/Wrappers/Enclave/Ocall_wrappers.h
+++ b/Wrappers/Enclave/Ocall_wrappers.h
@@ -32,7 +32,7 @@ int sgx_read(int fd, void *buf, int n);
 int sgx_write(int fd, const void *buf, int n);
 int sgx_close(int fd);
 char *sgx_getenv(const char *env);
-int sgx_printf(const char *fmt, ...);
+void sgx_printf(const char *fmt, ...);
 void sgx_printe(const char *fname, const char *fmt, ...);
 void sgx_printl(const char *fname, const char *fmt, ...);
 long sgx_rand(void);


### PR DESCRIPTION
There are some awkward spaces where the rest of `Ocall_implements.cpp` uses tabs.

Before, `sgx_printf` was non-void but didn't return. Alternatively, `ocall_print_string` could pass along the return value and/or errno from `printf`.