### PR TITLE
Include stdint.h in ssl_enclave_types.h

### DIFF
--- a/Wrappers/Enclave/ssl_enclave_types.h
+++ b/Wrappers/Enclave/ssl_enclave_types.h
@@ -1,6 +1,8 @@
 #ifndef _SSL_ENCLAVE_TYPES_
 #define _SSL_ENCLAVE_TYPES_
 
+#include <stdint.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
The sample code version already included the header.