### PR TITLE
Move Enclave_t.h and sgx_trts out of headers, and fix some style issues

### DIFF
--- a/SampleCode/Simple_TLS_Client/Enclave/Enclave.cpp
+++ b/SampleCode/Simple_TLS_Client/Enclave/Enclave.cpp
@@ -1,4 +1,4 @@
-
+#include "Enclave_t.h"
 #include "Ocall_wrappers.h"
 
 #include <openssl/ssl.h>

--- a/SampleCode/Simple_TLS_Client/Enclave/Enclave.cpp
+++ b/SampleCode/Simple_TLS_Client/Enclave/Enclave.cpp
@@ -8,7 +8,7 @@
 static void init_openssl()
 {
 	OpenSSL_add_ssl_algorithms();
-    OpenSSL_add_all_ciphers();
+	OpenSSL_add_all_ciphers();
 	SSL_load_error_strings();
 }
 
@@ -122,11 +122,11 @@ static int create_socket_client(const char *ip, uint32_t port)
 	int sockfd;
 	struct sockaddr_in dest_addr;
 
-    sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if(sockfd < 0) {
+	sockfd = socket(AF_INET, SOCK_STREAM, 0);
+	if(sockfd < 0) {
 		printe("socket");
 		exit(EXIT_FAILURE);
-    }
+	}
 
 	dest_addr.sin_family=AF_INET;
 	dest_addr.sin_port=htons(port);
@@ -159,8 +159,8 @@ static SSL_CTX *create_context()
 
 void ecall_start_tls_client(void)
 {
-	SSL *ssl;
-	int sock;
+    SSL *ssl;
+    int sock;
     SSL_CTX *ctx;
     const long flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
     const char *serv_ip = "127.0.0.1";
@@ -175,19 +175,19 @@ void ecall_start_tls_client(void)
 
     ssl = SSL_new(ctx);
     SSL_set_fd(ssl, sock);
-	if (SSL_connect(ssl) <= 0) {
+    if (SSL_connect(ssl) <= 0) {
         printe("SSL_connect");
         exit(EXIT_FAILURE);
-	}
+    }
  
-    printl("ciphersuit: %s", SSL_get_current_cipher(ssl)->name);
+    printl("ciphersuite: %s", SSL_get_current_cipher(ssl)->name);
     /* Send buffer to TLS server */
     const char *send_buf = "Hello TLS Server!";
-	SSL_write(ssl, send_buf, strlen(send_buf)+1);
+    SSL_write(ssl, send_buf, strlen(send_buf)+1);
 
     printl("Close SSL/TLS client");
     
-	SSL_free(ssl);
+    SSL_free(ssl);
     SSL_CTX_free(ctx);
     sgx_close(sock);
     cleanup_openssl();

--- a/SampleCode/Simple_TLS_Client/Enclave/Enclave.edl
+++ b/SampleCode/Simple_TLS_Client/Enclave/Enclave.edl
@@ -5,12 +5,12 @@ enclave {
 
 	from "sgx_tstdc.edl" import *;
 	
-    trusted {
+	trusted {
 		public void ecall_start_tls_client(void);
 	};
 
-    untrusted {
-		long ocall_sgx_clock(void);		/* For Performance evaluation */
+	untrusted {
+		long ocall_sgx_clock(void); // For performance evaluation
 		time_t ocall_sgx_time([out, size=t_len]time_t *timep, int t_len);
 		struct tm *ocall_sgx_localtime([in, size=t_len]const time_t *timep, int t_len);
 		struct tm *ocall_sgx_gmtime_r([in, size=t_len]const time_t *timep, int t_len, [out, size=tmp_len]struct tm *tmp, int tmp_len);
@@ -28,6 +28,6 @@ enclave {
 		int ocall_sgx_close(int fd);
 		int ocall_sgx_getenv([in,size=envlen]const char *env, int envlen, [out,size=ret_len]char *ret_str,int ret_len);
 		void ocall_print_string([in, string] const char *str);        
-    };
+	};
 
 };

--- a/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.cpp
+++ b/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.cpp
@@ -1,4 +1,6 @@
 #include "Ocall_wrappers.h"
+#include "Enclave_t.h"
+#include "sgx_trts.h"
 
 long sgx_clock(void)
 {

--- a/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.cpp
+++ b/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.cpp
@@ -128,7 +128,6 @@ int sgx_accept(int s, struct sockaddr *addr, int *addrlen)
 		printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
 		sgx_exit(EXIT_FAILURE);
 	}
-	sockaddr_in *addr_in = (sockaddr_in *)addr;
 	return retv;
 }
 

--- a/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.h
+++ b/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-long sgx_clock(void); /* For Performance evaluation */
+long sgx_clock(void); // For performance evaluation
 time_t sgx_time(time_t *timep);
 struct tm *sgx_localtime(const time_t *timep);
 struct tm *sgx_gmtime_r(const time_t *timep, struct tm *tmp);

--- a/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.h
+++ b/SampleCode/Simple_TLS_Client/Enclave/Ocall_wrappers.h
@@ -5,11 +5,9 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <assert.h>
+#include <time.h>
 
-#include "sgx_trts.h"
 #include "ssl_enclave_types.h"
-
-#include "Enclave_t.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/SampleCode/Simple_TLS_Server/Enclave/Enclave.cpp
+++ b/SampleCode/Simple_TLS_Server/Enclave/Enclave.cpp
@@ -1,3 +1,4 @@
+#include "Enclave_t.h"
 #include "Ocall_wrappers.h"
 
 #include <openssl/ssl.h>

--- a/SampleCode/Simple_TLS_Server/Enclave/Enclave.cpp
+++ b/SampleCode/Simple_TLS_Server/Enclave/Enclave.cpp
@@ -7,7 +7,7 @@
 static void init_openssl()
 {
 	OpenSSL_add_ssl_algorithms();
-    OpenSSL_add_all_ciphers();
+	OpenSSL_add_all_ciphers();
 	SSL_load_error_strings();
 }
 
@@ -67,7 +67,7 @@ static X509 *generateCertificate(EVP_PKEY *pkey)
 
 static void configure_context(SSL_CTX *ctx)
 {
-    EVP_PKEY *pkey = generatePrivateKey();
+	EVP_PKEY *pkey = generatePrivateKey();
 	X509 *x509 = generateCertificate(pkey);
 
 	SSL_CTX_use_certificate(ctx, x509);
@@ -92,20 +92,20 @@ static int create_socket_server(int port)
 
     s = socket(AF_INET, SOCK_STREAM, 0);
     if (s < 0) {
-    	printe("sgx_socket");
-		exit(EXIT_FAILURE);
+        printe("sgx_socket");
+        exit(EXIT_FAILURE);
     }
     if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (const void *)&optval, sizeof(int)) < 0) {
-		printe("sgx_setsockopt");
-		exit(EXIT_FAILURE);
+        printe("sgx_setsockopt");
+        exit(EXIT_FAILURE);
     }
     if (bind(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-    	printe("sgx_bind");
-		exit(EXIT_FAILURE);
+        printe("sgx_bind");
+        exit(EXIT_FAILURE);
     }
     if (listen(s, 128) < 0) {
-    	printe("sgx_listen");
-		exit(EXIT_FAILURE);
+        printe("sgx_listen");
+        exit(EXIT_FAILURE);
     }
     return s;
 }
@@ -122,8 +122,8 @@ void ecall_start_tls_server(void)
 
     sock = create_socket_server(4433);
     if(sock < 0) {
-		printe("create_socket_client");
-		exit(EXIT_FAILURE);
+        printe("create_socket_client");
+        exit(EXIT_FAILURE);
     }
 
     /* Handle SSL/TLS connections */
@@ -140,9 +140,9 @@ void ecall_start_tls_server(void)
             exit(EXIT_FAILURE);
         }
 
-		cli = SSL_new(ctx);
+	cli = SSL_new(ctx);
         SSL_set_fd(cli, client);
-		if (SSL_accept(cli) <= 0) {
+	if (SSL_accept(cli) <= 0) {
             printe("SSL_accept");
             exit(EXIT_FAILURE);
         }

--- a/SampleCode/Simple_TLS_Server/Enclave/Enclave.edl
+++ b/SampleCode/Simple_TLS_Server/Enclave/Enclave.edl
@@ -5,29 +5,29 @@ enclave {
 
 	from "sgx_tstdc.edl" import *;
 	
-    trusted {
+	trusted {
 		public void ecall_start_tls_server(void);
 	};
 
-    untrusted {
-		long ocall_sgx_clock(void);		/* For Performance evaluation */
+	untrusted {
+		long ocall_sgx_clock(void); // For performance evaluation
 		time_t ocall_sgx_time([out, size=t_len]time_t *timep, int t_len);
 		struct tm *ocall_sgx_localtime([in, size=t_len]const time_t *timep, int t_len);
 		struct tm *ocall_sgx_gmtime_r([in, size=t_len]const time_t *timep, int t_len, [out, size=tmp_len]struct tm *tmp, int tmp_len);
 		int ocall_sgx_gettimeofday([in, out, size=tv_size]void *tv, int tv_size); 
 		int ocall_sgx_getsockopt(int s, int level, int optname, [out, size=optval_len]char *optval, int optval_len, [in,out, size=4]int* optlen);
-        int ocall_sgx_setsockopt(int s, int level, int optname, [in, size=optlen]const void *optval, int optlen);
-        int ocall_sgx_socket(int af, int type, int protocol);		
+		int ocall_sgx_setsockopt(int s, int level, int optname, [in, size=optlen]const void *optval, int optlen);
+		int ocall_sgx_socket(int af, int type, int protocol);
 		int ocall_sgx_listen(int s, int backlog);
 		int ocall_sgx_bind(int s, [in, size=addr_size]const void *addr, int addr_size);
 		int ocall_sgx_connect(int s, [in, size=addrlen]const void *addr, int addrlen);
-		int ocall_sgx_accept(int s, [out, size=addr_size]void *addr, int addr_size, [in, out, size=4]int *addrlen); 
+		int ocall_sgx_accept(int s, [out, size=addr_size]void *addr, int addr_size, [in, out, size=4]int *addrlen);
 		int ocall_sgx_shutdown(int fd, int how);
 		int ocall_sgx_read(int fd, [out, size=n]void *buf, int n);
 		int ocall_sgx_write(int fd, [in, size=n]const void *buf, int n);
 		int ocall_sgx_close(int fd);
 		int ocall_sgx_getenv([in,size=envlen]const char *env, int envlen, [out,size=ret_len]char *ret_str,int ret_len);
 		void ocall_print_string([in, string] const char *str);        
-    };
+	};
 
 };

--- a/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.cpp
+++ b/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.cpp
@@ -1,4 +1,6 @@
 #include "Ocall_wrappers.h"
+#include "Enclave_t.h"
+#include "sgx_trts.h"
 
 long sgx_clock(void)
 {

--- a/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.cpp
+++ b/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.cpp
@@ -128,7 +128,6 @@ int sgx_accept(int s, struct sockaddr *addr, int *addrlen)
 		printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
 		sgx_exit(EXIT_FAILURE);
 	}
-	sockaddr_in *addr_in = (sockaddr_in *)addr;
 	return retv;
 }
 

--- a/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.h
+++ b/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-long sgx_clock(void); /* For Performance evaluation */
+long sgx_clock(void); // For performance evaluation
 time_t sgx_time(time_t *timep);
 struct tm *sgx_localtime(const time_t *timep);
 struct tm *sgx_gmtime_r(const time_t *timep, struct tm *tmp);

--- a/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.h
+++ b/SampleCode/Simple_TLS_Server/Enclave/Ocall_wrappers.h
@@ -5,11 +5,9 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <assert.h>
+#include <time.h>
 
-#include "sgx_trts.h"
 #include "ssl_enclave_types.h"
-
-#include "Enclave_t.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/Wrappers/Enclave/Enclave.edl
+++ b/Wrappers/Enclave/Enclave.edl
@@ -6,19 +6,19 @@ enclave {
 
 	from "sgx_tstdc.edl" import *;
 	
-    untrusted {
-		long ocall_sgx_clock(void);		/* For Performance evaluation */
+	untrusted {
+		long ocall_sgx_clock(void); // For performance evaluation
 		time_t ocall_sgx_time([out, size=t_len]time_t *timep, int t_len);
 		struct tm *ocall_sgx_localtime([in, size=t_len]const time_t *timep, int t_len);
 		struct tm *ocall_sgx_gmtime_r([in, size=t_len]const time_t *timep, int t_len, [out, size=tmp_len]struct tm *tmp, int tmp_len);
-		int ocall_sgx_gettimeofday([in, out, size=tv_size]void *tv, int tv_size); 
+		int ocall_sgx_gettimeofday([in, out, size=tv_size]void *tv, int tv_size);
 		int ocall_sgx_getsockopt(int s, int level, int optname, [out, size=optval_len]char *optval, int optval_len, [in,out, size=4]int* optlen);
 		int ocall_sgx_setsockopt(int s, int level, int optname, [in, size=optlen]const void *optval, int optlen);
-		int ocall_sgx_socket(int af, int type, int protocol);		
+		int ocall_sgx_socket(int af, int type, int protocol);
 		int ocall_sgx_listen(int s, int backlog);
 		int ocall_sgx_bind(int s, [in, size=addr_size]const void *addr, int addr_size);
 		int ocall_sgx_connect(int s, [in, size=addrlen]const void *addr, int addrlen);
-		int ocall_sgx_accept(int s, [out, size=addr_size]void *addr, int addr_size, [in, out, size=4]int *addrlen); 
+		int ocall_sgx_accept(int s, [out, size=addr_size]void *addr, int addr_size, [in, out, size=4]int *addrlen);
 		int ocall_sgx_shutdown(int fd, int how);
 		int ocall_sgx_read(int fd, [out, size=n]void *buf, int n);
 		int ocall_sgx_write(int fd, [in, size=n]const void *buf, int n);

--- a/Wrappers/Enclave/Ocall_wrappers.cpp
+++ b/Wrappers/Enclave/Ocall_wrappers.cpp
@@ -1,4 +1,6 @@
 #include "Ocall_wrappers.h"
+#include "Enclave_t.h"
+#include "sgx_trts.h"
 
 long sgx_clock(void)
 {

--- a/Wrappers/Enclave/Ocall_wrappers.cpp
+++ b/Wrappers/Enclave/Ocall_wrappers.cpp
@@ -128,7 +128,6 @@ int sgx_accept(int s, struct sockaddr *addr, int *addrlen)
 		printf("OCALL FAILED!, Error code = %d\n", sgx_retv);
 		sgx_exit(EXIT_FAILURE);
 	}
-	sockaddr_in *addr_in = (sockaddr_in *)addr;
 	return retv;
 }
 

--- a/Wrappers/Enclave/Ocall_wrappers.h
+++ b/Wrappers/Enclave/Ocall_wrappers.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-long sgx_clock(void); /* For Performance evaluation */
+long sgx_clock(void); // For performance evaluation
 time_t sgx_time(time_t *timep);
 struct tm *sgx_localtime(const time_t *timep);
 struct tm *sgx_gmtime_r(const time_t *timep, struct tm *tmp);

--- a/Wrappers/Enclave/Ocall_wrappers.h
+++ b/Wrappers/Enclave/Ocall_wrappers.h
@@ -5,11 +5,9 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <assert.h>
+#include <time.h>
 
-#include "sgx_trts.h"
 #include "ssl_enclave_types.h"
-
-#include "Enclave_t.h"
 
 #if defined(__cplusplus)
 extern "C" {


### PR DESCRIPTION
`Enclave_t.h` and `sgx_trts.h` didn't need to be included in `Ocall_wrappers.h`, so I moved them to the source files, so that the header no longer depends on the name of the enclave.

I also tried to make indentation at least consistent within a function, and deleted an extraneous statement.